### PR TITLE
Test Version 1.0.0.7

### DIFF
--- a/App.config
+++ b/App.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
             <section name="LottoDataManager.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
     </configSections>
@@ -39,4 +39,12 @@
             </setting>
         </LottoDataManager.Properties.Settings>
     </userSettings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/App.config
+++ b/App.config
@@ -32,7 +32,7 @@
                 <value>0</value>
             </setting>
             <setting name="version_release" serializeAs="String">
-                <value>6</value>
+                <value>7</value>
             </setting>
             <setting name="repository_name" serializeAs="String">
                 <value>LottoDataManager</value>

--- a/Forms/MainFrm.Designer.cs
+++ b/Forms/MainFrm.Designer.cs
@@ -173,7 +173,7 @@ namespace LottoDataManager
             this.othersToolStripMenuItem});
             this.mainMenuStrip.Location = new System.Drawing.Point(0, 0);
             this.mainMenuStrip.Name = "mainMenuStrip";
-            this.mainMenuStrip.Size = new System.Drawing.Size(1233, 30);
+            this.mainMenuStrip.Size = new System.Drawing.Size(1233, 28);
             this.mainMenuStrip.TabIndex = 0;
             this.mainMenuStrip.Text = "mainMenuStrip";
             // 
@@ -183,7 +183,7 @@ namespace LottoDataManager
             this.openLotteryToolStripMenuItem,
             this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 26);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // openLotteryToolStripMenuItem
@@ -210,7 +210,7 @@ namespace LottoDataManager
             this.modifyClaimStatusToolStripMenuItem,
             this.moveDrawDateToolStripMenuItem1});
             this.ticketToolStripMenuItem.Name = "ticketToolStripMenuItem";
-            this.ticketToolStripMenuItem.Size = new System.Drawing.Size(62, 26);
+            this.ticketToolStripMenuItem.Size = new System.Drawing.Size(62, 24);
             this.ticketToolStripMenuItem.Text = "Ticket";
             // 
             // seqGenToolStripMenuItem
@@ -258,7 +258,7 @@ namespace LottoDataManager
             this.reportsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.lossProfitToolStripMenuItem});
             this.reportsToolStripMenuItem.Name = "reportsToolStripMenuItem";
-            this.reportsToolStripMenuItem.Size = new System.Drawing.Size(74, 26);
+            this.reportsToolStripMenuItem.Size = new System.Drawing.Size(74, 24);
             this.reportsToolStripMenuItem.Text = "Reports";
             // 
             // lossProfitToolStripMenuItem
@@ -274,7 +274,7 @@ namespace LottoDataManager
             this.settingsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.lotterySettingToolStripMenuItem});
             this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
-            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(76, 26);
+            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(76, 24);
             this.settingsToolStripMenuItem.Text = "Settings";
             // 
             // lotterySettingToolStripMenuItem
@@ -295,7 +295,7 @@ namespace LottoDataManager
             this.aboutToolStripMenuItem1,
             this.updatesToolStripMenuItem});
             this.othersToolStripMenuItem.Name = "othersToolStripMenuItem";
-            this.othersToolStripMenuItem.Size = new System.Drawing.Size(66, 26);
+            this.othersToolStripMenuItem.Size = new System.Drawing.Size(66, 24);
             this.othersToolStripMenuItem.Text = "Others";
             // 
             // checkWinningBetsToolStripMenuItem
@@ -371,7 +371,7 @@ namespace LottoDataManager
             // 
             this.mainSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
             this.mainSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
-            this.mainSplitContainer.Location = new System.Drawing.Point(0, 30);
+            this.mainSplitContainer.Location = new System.Drawing.Point(0, 28);
             this.mainSplitContainer.Name = "mainSplitContainer";
             // 
             // mainSplitContainer.Panel1
@@ -382,7 +382,7 @@ namespace LottoDataManager
             // 
             this.mainSplitContainer.Panel2.Controls.Add(this.panel3);
             this.mainSplitContainer.Panel2.Controls.Add(this.toolStripBetsAndResults);
-            this.mainSplitContainer.Size = new System.Drawing.Size(1233, 526);
+            this.mainSplitContainer.Size = new System.Drawing.Size(1233, 528);
             this.mainSplitContainer.SplitterDistance = 500;
             this.mainSplitContainer.TabIndex = 2;
             // 
@@ -393,7 +393,7 @@ namespace LottoDataManager
             this.mainLeftTabControl.Location = new System.Drawing.Point(0, 0);
             this.mainLeftTabControl.Name = "mainLeftTabControl";
             this.mainLeftTabControl.SelectedIndex = 0;
-            this.mainLeftTabControl.Size = new System.Drawing.Size(500, 526);
+            this.mainLeftTabControl.Size = new System.Drawing.Size(500, 528);
             this.mainLeftTabControl.TabIndex = 0;
             // 
             // tabDashboard
@@ -403,7 +403,7 @@ namespace LottoDataManager
             this.tabDashboard.Location = new System.Drawing.Point(4, 25);
             this.tabDashboard.Name = "tabDashboard";
             this.tabDashboard.Padding = new System.Windows.Forms.Padding(3);
-            this.tabDashboard.Size = new System.Drawing.Size(492, 497);
+            this.tabDashboard.Size = new System.Drawing.Size(492, 499);
             this.tabDashboard.TabIndex = 0;
             this.tabDashboard.Text = "Dashboard";
             this.tabDashboard.UseVisualStyleBackColor = true;
@@ -414,7 +414,7 @@ namespace LottoDataManager
             this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel2.Location = new System.Drawing.Point(3, 117);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(486, 377);
+            this.panel2.Size = new System.Drawing.Size(486, 379);
             this.panel2.TabIndex = 11;
             // 
             // objLVDashboard
@@ -435,7 +435,7 @@ namespace LottoDataManager
             this.objLVDashboard.Location = new System.Drawing.Point(0, 0);
             this.objLVDashboard.MultiSelect = false;
             this.objLVDashboard.Name = "objLVDashboard";
-            this.objLVDashboard.Size = new System.Drawing.Size(486, 377);
+            this.objLVDashboard.Size = new System.Drawing.Size(486, 379);
             this.objLVDashboard.SortGroupItemsByPrimaryColumn = false;
             this.objLVDashboard.TabIndex = 4;
             this.objLVDashboard.UseCompatibleStateImageBehavior = false;
@@ -562,7 +562,7 @@ namespace LottoDataManager
             this.panel3.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel3.Location = new System.Drawing.Point(0, 37);
             this.panel3.Name = "panel3";
-            this.panel3.Size = new System.Drawing.Size(729, 489);
+            this.panel3.Size = new System.Drawing.Size(729, 491);
             this.panel3.TabIndex = 17;
             // 
             // splitContainerWinningAndBet
@@ -578,7 +578,7 @@ namespace LottoDataManager
             // splitContainerWinningAndBet.Panel2
             // 
             this.splitContainerWinningAndBet.Panel2.Controls.Add(this.groupBox2);
-            this.splitContainerWinningAndBet.Size = new System.Drawing.Size(729, 424);
+            this.splitContainerWinningAndBet.Size = new System.Drawing.Size(729, 426);
             this.splitContainerWinningAndBet.SplitterDistance = 268;
             this.splitContainerWinningAndBet.TabIndex = 12;
             // 
@@ -590,7 +590,7 @@ namespace LottoDataManager
             this.groupBox1.ForeColor = System.Drawing.Color.Green;
             this.groupBox1.Location = new System.Drawing.Point(0, 0);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(268, 424);
+            this.groupBox1.Size = new System.Drawing.Size(268, 426);
             this.groupBox1.TabIndex = 20;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Latest List";
@@ -628,7 +628,7 @@ namespace LottoDataManager
             this.objectLstVwLatestBet.SelectedColumnTint = System.Drawing.Color.FromArgb(((int)(((byte)(15)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
             this.objectLstVwLatestBet.SelectedForeColor = System.Drawing.Color.White;
             this.objectLstVwLatestBet.ShowGroups = false;
-            this.objectLstVwLatestBet.Size = new System.Drawing.Size(262, 398);
+            this.objectLstVwLatestBet.Size = new System.Drawing.Size(262, 400);
             this.objectLstVwLatestBet.TabIndex = 12;
             this.objectLstVwLatestBet.UseCompatibleStateImageBehavior = false;
             this.objectLstVwLatestBet.View = System.Windows.Forms.View.Details;
@@ -636,6 +636,7 @@ namespace LottoDataManager
             this.objectLstVwLatestBet.SelectionChanged += new System.EventHandler(this.objectLstVwLatestBet_SelectionChanged);
             this.objectLstVwLatestBet.DoubleClick += new System.EventHandler(this.objectLstVwLatestBet_DoubleClick);
             this.objectLstVwLatestBet.KeyDown += new System.Windows.Forms.KeyEventHandler(this.objectLstVwLatestBet_KeyDown);
+            this.objectLstVwLatestBet.KeyUp += new System.Windows.Forms.KeyEventHandler(this.objectLstVwLatestBet_KeyUp);
             // 
             // olvColBetDrawDate
             // 
@@ -782,7 +783,7 @@ namespace LottoDataManager
             this.groupBox2.ForeColor = System.Drawing.Color.Tomato;
             this.groupBox2.Location = new System.Drawing.Point(0, 0);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(457, 424);
+            this.groupBox2.Size = new System.Drawing.Size(457, 426);
             this.groupBox2.TabIndex = 20;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Draw Results List";
@@ -824,7 +825,7 @@ namespace LottoDataManager
             this.objListVwWinningNum.SelectedColumnTint = System.Drawing.Color.FromArgb(((int)(((byte)(15)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
             this.objListVwWinningNum.SelectedForeColor = System.Drawing.Color.White;
             this.objListVwWinningNum.ShowGroups = false;
-            this.objListVwWinningNum.Size = new System.Drawing.Size(451, 398);
+            this.objListVwWinningNum.Size = new System.Drawing.Size(451, 400);
             this.objListVwWinningNum.TabIndex = 2;
             this.objListVwWinningNum.UseCompatibleStateImageBehavior = false;
             this.objListVwWinningNum.View = System.Windows.Forms.View.Details;

--- a/Forms/MainFrm.cs
+++ b/Forms/MainFrm.cs
@@ -765,7 +765,7 @@ namespace LottoDataManager
             LotterySettingsFrm settings = new LotterySettingsFrm(lotteryDataServices);
             settings.ShowDialog(this);
             if(settings.IsSourceDatabaseChange) DoApplicationUpdate();
-            RefreshBets();
+            SetBetsAndResultDefaultList();
         }
         private void checkWinningBetsToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/Forms/MainFrm.cs
+++ b/Forms/MainFrm.cs
@@ -167,19 +167,19 @@ namespace LottoDataManager
                 {
                     if (rowObject == null) return 0;
                     LotteryDrawResult p = (LotteryDrawResult)rowObject;
-                    if (p.GetWinners() <= 0) return "0";
-                    return p.GetWinners();
+                    if (p.GetWinnersCount() <= 0) return "0";
+                    return p.GetWinnersCount();
                 };
                 this.olvColWinStamp.ImageGetter = delegate (object rowObject) {
                     if (rowObject == null) return 0;
                     LotteryDrawResult p = (LotteryDrawResult)rowObject;
-                    if (p.GetWinners() <= 0) return 0;
+                    if (p.GetWinnersCount() <= 0) return 0;
                     return ImageUtils.GetStarJackpotImage(5);
                 };
                 this.olvColWinStamp.AspectGetter = delegate (object rowObject) {
                     if (rowObject == null) return 0;
                     LotteryDrawResult p = (LotteryDrawResult)rowObject;
-                    return p.GetWinners();
+                    return p.GetWinnersCount();
                 };
                 this.olvColWinStamp.AspectToStringConverter = delegate (object rowObject) {
                     return String.Empty;
@@ -452,7 +452,7 @@ namespace LottoDataManager
         {
             if (e.Model == null) return;
             LotteryDrawResult result = (LotteryDrawResult)e.Model;
-            if(result.GetWinners() > 0)
+            if(result.GetWinnersCount() > 0)
             {
                 e.Item.BackColor = Color.GreenYellow;
                 e.Item.ForeColor = Color.Black;
@@ -554,6 +554,15 @@ namespace LottoDataManager
             objectLstVwLatestBet.SelectAll();
         }
         private void copySelectedAsLinearCSVToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            ObjectLstVwLatestBetClipboardCopy();
+        }
+        private void objectLstVwLatestBet_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Control && e.KeyCode == Keys.C) ObjectLstVwLatestBetClipboardCopy();
+            if (e.Control && e.KeyCode == Keys.A) objectLstVwLatestBet.SelectAll();
+        }
+        private void ObjectLstVwLatestBetClipboardCopy()
         {
             try
             {
@@ -845,6 +854,7 @@ namespace LottoDataManager
                 MessageBox.Show(ResourcesUtils.GetMessage("mainf_labels_45"));
             }
         }
+
         private void exitToolStripMenuItem_Click(object sender, EventArgs e)
         {
             this.Close();
@@ -876,12 +886,10 @@ namespace LottoDataManager
         {
             DoApplicationUpdate();
         }
-
         private void DoApplicationUpdate()
         {
             this.applicationUpdateProcessor.StartUpdate(lotteryDataServices);
         }
-
         #endregion
 
     }

--- a/Forms/Others/HitComparisonFrm.cs
+++ b/Forms/Others/HitComparisonFrm.cs
@@ -202,13 +202,13 @@ namespace LottoDataManager.Forms.Others
             this.olvColDrawWinner.ImageGetter = delegate (object rowObject) {
                 if (rowObject == null) return 0;
                 LotteryDrawResult p = (LotteryDrawResult)rowObject;
-                if (p.GetWinners() <= 0) return 0;
+                if (p.GetWinnersCount() <= 0) return 0;
                 return ImageUtils.GetStarJackpotImage(5);
             };
             this.olvColDrawWinner.AspectGetter = delegate (object rowObject) {
                 if (rowObject == null) return 0;
                 LotteryDrawResult p = (LotteryDrawResult)rowObject;
-                return p.GetWinners();
+                return p.GetWinnersCount();
             };
             this.olvColDrawWinner.AspectToStringConverter = delegate (object rowObject) {
                 return String.Empty;

--- a/Forms/ProcessingStatusLogFrm.cs
+++ b/Forms/ProcessingStatusLogFrm.cs
@@ -37,6 +37,7 @@ namespace LottoDataManager.Forms
             richtbLogs.SelectionStart = 0;
             richtbLogs.SelectionLength = 0;
             richtbLogs.ScrollToCaret();
+            richtbLogs.Refresh();
         }
         #endregion
 
@@ -44,9 +45,11 @@ namespace LottoDataManager.Forms
 
         private void ProcessingStatusLogFrm_HandleCreated(object sender, EventArgs e)
         {
+            int ctrRefresher = 0;
             foreach(String[] logsEntry in statusLogsDelayed)
             {
                 AddStatusLogsDisplayOnTextBox(logsEntry[0], logsEntry[1], logsEntry[2]);
+                if (ctrRefresher % 30 == 0) Application.DoEvents();
             }
             statusLogsDelayed.Clear();
         }
@@ -74,8 +77,6 @@ namespace LottoDataManager.Forms
             richtbLogs.SelectionColor = color;
             richtbLogs.AppendText(message);
             richtbLogs.SelectionColor = richtbLogs.ForeColor;
-            richtbLogs.ScrollToCaret();
-            richtbLogs.Refresh();
         }
         public void ClearLogs()
         {

--- a/Forms/Ticket/AddBetFrm.cs
+++ b/Forms/Ticket/AddBetFrm.cs
@@ -80,7 +80,7 @@ namespace LottoDataManager.Forms
             dtPickPreferredDate.Visible = false;
 
             //select default if no selection
-            if(cmbSeqGenType.SelectedItem == null) SelectedSequenceGenerator = GeneratorType.PERSONAL_PICK;
+            if (cmbSeqGenType.SelectedItem == null) SelectedSequenceGenerator = GeneratorType.PERSONAL_PICK;
         }
         private void RefreshSelectedDrawDate()
         {
@@ -105,6 +105,8 @@ namespace LottoDataManager.Forms
         private void btnExit_Click(object sender, EventArgs e)
         {
             this.Close();
+            textBoxDelimitersInput.Text = String.Empty;
+            ClearTicketLayoutSelection();
             if (!this.hasDataBeenSave) return;
             ClassReflectionUtil.RefreshMainFormBets(this);
         }
@@ -409,6 +411,10 @@ namespace LottoDataManager.Forms
             lblSelectedNumber.Text = numSelected;
         }
         private void linkLblClrSelNum_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            ClearTicketLayoutSelection();
+        }
+        private void ClearTicketLayoutSelection()
         {
             selTcktPnlNum.Clear();
             AddSelectedTicketPanelNumber();

--- a/Forms/Ticket/ModifyBetDateFrm.cs
+++ b/Forms/Ticket/ModifyBetDateFrm.cs
@@ -153,8 +153,16 @@ namespace LottoDataManager.Forms
             }
             else if (newDateTime.CompareTo(DateTime.Now.Date) == 0) //if the same
             {
-                log(ResourcesUtils.GetMessage("mdd_form_validation_msg6"));
-                return false;
+                if (lotteryDataServices.IsPastTicketSellingCutoffTime())
+                {
+                    DialogResult drPassCutOfftime = MessageBox.Show(ResourcesUtils.GetMessage("mdd_form_validation_msg8"),
+                        ResourcesUtils.GetMessage("mdd_form_others_mgs7"), MessageBoxButtons.OKCancel, MessageBoxIcon.Exclamation);
+                    if(drPassCutOfftime != DialogResult.OK)
+                    {
+                        log(ResourcesUtils.GetMessage("mdd_form_validation_msg6"));
+                        return false;
+                    }
+                }
             }
             return true;
         }

--- a/Forms/Ticket/ModifyBetFrm.cs
+++ b/Forms/Ticket/ModifyBetFrm.cs
@@ -254,10 +254,12 @@ namespace LottoDataManager.Forms
         private void DeleteLotteryBets()
         {
             if (objectListViewBets.CheckedObjects.Count <= 0) return;
+            DialogResult dr = DialogResult.Cancel;
             try
             {
-                DialogResult dr = MessageBox.Show(ResourcesUtils.GetMessage("modfy_bets_msg_7"),
-                         ResourcesUtils.GetMessage("modfy_bets_msg_8"), MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
+                dr = MessageBox.Show(ResourcesUtils.GetMessage("modfy_bets_msg_7"),
+                         ResourcesUtils.GetMessage("modfy_bets_msg_8"), MessageBoxButtons.OKCancel, 
+                         MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2);
                 if (dr == DialogResult.OK)
                 {
                     toolStripProgBar.Value = 0;
@@ -272,6 +274,7 @@ namespace LottoDataManager.Forms
                         this.lotteryDataServices.DeleteLotteryBet(lotBet);
                         Application.DoEvents();
                     }
+                    if (totalCheckedObjects > 0) hasDataUpdates = true;
                 }
             }
             catch (Exception ex)
@@ -283,7 +286,7 @@ namespace LottoDataManager.Forms
                 toolStripStatusLbl.Text = "";
                 toolStripProgBar.Value = 0;
                 toolStripProgBar.Visible = false;
-                FillUpBetList();
+                if (dr == DialogResult.OK) FillUpBetList();
             }
         }
         private void SaveLotteryBetsChanges()

--- a/Includes/Classes/Reports/DashboardReport.cs
+++ b/Includes/Classes/Reports/DashboardReport.cs
@@ -394,6 +394,7 @@ namespace LottoDataManager.Includes.Classes.Reports
 
             foreach(LotteryDrawResult draw in latestDrawResults)
             {
+                if (draw == null) continue;
                 Lottery lottery = lotteriesGameList.Find((lotteryObj) => (int)lotteryObj.GetGameMode() == draw.GetGameCode());
                 DateTime today = DateTime.Now;
                 TimeSpan diffWithToday = today - draw.GetDrawDate();
@@ -419,6 +420,7 @@ namespace LottoDataManager.Includes.Classes.Reports
 
             foreach (LotteryDrawResult draw in latestDrawResults)
             {
+                if (draw == null) continue;
                 Lottery lottery = lotteriesGameList.Find((lotteryObj) => (int)lotteryObj.GetGameMode() == draw.GetGameCode());
                 String key = lottery.GetDescription();
                 String value = draw.GetJackpotAmtFormatted();

--- a/Includes/Classes/Reports/DashboardReport.cs
+++ b/Includes/Classes/Reports/DashboardReport.cs
@@ -423,7 +423,10 @@ namespace LottoDataManager.Includes.Classes.Reports
                 if (draw == null) continue;
                 Lottery lottery = lotteriesGameList.Find((lotteryObj) => (int)lotteryObj.GetGameMode() == draw.GetGameCode());
                 String key = lottery.GetDescription();
-                String value = draw.GetJackpotAmtFormatted();
+                String value = (draw.HasWinners()) ? 
+                    ResourcesUtils.GetMessage("drpt_lot_draw_jackpot_winners_lbl", 
+                        draw.GetJackpotAmtFormatted(), draw.GetWinnersCount().ToString()) : 
+                        draw.GetJackpotAmtFormatted();
                 DashboardReportItemSetup itm = GenModel(key, value);
                 itm.GroupKeyName = ResourcesUtils.GetMessage("drpt_lot_draw_jackpot_lbl");
                 itm.ReportItemDecoration.IsHyperLink = true;

--- a/Includes/Database/DAO/Impl/LotteryDrawResultDaoImpl.cs
+++ b/Includes/Database/DAO/Impl/LotteryDrawResultDaoImpl.cs
@@ -207,7 +207,7 @@ namespace LottoDataManager.Includes.Database.DAO
                                       " VALUES (@draw_date,@jackpot_amt,@winners,@game_cd,@num1,@num2,@num3,@num4,@num5,@num6)";
                 command.Parameters.AddWithValue("@draw_date", lotteryDrawResult.GetDrawDate());
                 command.Parameters.AddWithValue("@jackpot_amt", lotteryDrawResult.GetJackpotAmt());
-                command.Parameters.AddWithValue("@winners", lotteryDrawResult.GetWinners());
+                command.Parameters.AddWithValue("@winners", lotteryDrawResult.GetWinnersCount());
                 command.Parameters.AddWithValue("@game_cd", lotteryDrawResult.GetGameCode());
                 command.Parameters.AddWithValue("@num1", lotteryDrawResult.GetNum1());
                 command.Parameters.AddWithValue("@num2", lotteryDrawResult.GetNum2());

--- a/Includes/Database/DAO/Impl/UserSettingDaoImpl.cs
+++ b/Includes/Database/DAO/Impl/UserSettingDaoImpl.cs
@@ -121,7 +121,7 @@ namespace LottoDataManager.Includes.Database.DAO.Impl
         }
         public void SaveLastOpenedLottery(int game_cd)
         {
-            UpdateSetting(game_cd.ToString(), UserSettingsConfig.CFG_LAST_OPENED_DIRECTORY);
+            UpdateSetting(UserSettingsConfig.CFG_LAST_OPENED_DIRECTORY, game_cd.ToString());
         }
         public String GetMLDataSetDirectoryPath()
         {
@@ -129,7 +129,7 @@ namespace LottoDataManager.Includes.Database.DAO.Impl
         }
         public void SaveMLDataSetDirectoryPath(String filePath)
         {
-            UpdateSetting(filePath, UserSettingsConfig.CFG_ML_DATA_SET);
+            UpdateSetting(UserSettingsConfig.CFG_ML_DATA_SET, filePath);
         }
     }
 }

--- a/Includes/Model/Details/LotteryDrawResult.cs
+++ b/Includes/Model/Details/LotteryDrawResult.cs
@@ -12,11 +12,12 @@ namespace LottoDataManager.Includes.Model.Details
         long GetID();
         double GetJackpotAmt();
         String GetJackpotAmtFormatted();
-        int GetWinners();
+        int GetWinnersCount();
         bool IsWithinDrawResult(int numberToLookFor);
         bool IsDrawResulDetailsEmpty();
         void PutNumberSequence(String sequence);
         bool IsDrawResulSequenceEmpty();
+        bool HasWinners();
         FastTreeInputModel GetFastTreeInputModel();
         SDCARegressionInputModel GetSDCARegressionInputModel();
         String GetFastTreeTrainerModelDataIntake();

--- a/Includes/Model/Details/Setup/LotteryDrawResultSetup.cs
+++ b/Includes/Model/Details/Setup/LotteryDrawResultSetup.cs
@@ -37,7 +37,7 @@ namespace LottoDataManager.Includes.Model.Details
         {
             return this.JackpotAmt;
         }
-        public int GetWinners()
+        public int GetWinnersCount()
         {
             return this.Winners;
         }
@@ -106,7 +106,6 @@ namespace LottoDataManager.Includes.Model.Details
                 DateTimeConverterUtils.ConvertToFormat(this.DrawDate, DateTimeConverterUtils.STANDARD_DATE_FORMAT), 
                 this.GetGNUFormat());
         }
-
         override
         public String ToString()
         {
@@ -118,7 +117,6 @@ namespace LottoDataManager.Includes.Model.Details
             return base.ToString();
 #endif
         }
-
         public String GetFastTreeTrainerModelDataIntake()
         {
             //draw_date,num1,num2,num3,num4,num5,num6,game_cd,RESULT
@@ -133,7 +131,6 @@ namespace LottoDataManager.Includes.Model.Details
                         Num5.ToString().PadLeft(2, char.Parse("0")),
                         Num6.ToString().PadLeft(2, char.Parse("0"))));
         }
-
         public String GetSCDARegressionModelDataIntake()
         {
             //draw_date,num1,num2,num3,num4,num5,num6,PREDICT,winners,game_cd
@@ -143,6 +140,9 @@ namespace LottoDataManager.Includes.Model.Details
                     (Num1 + Num2 + Num3 + Num4 + Num5 + Num6),
                     Winners, GameCode);
         }
-
+        public bool HasWinners()
+        {
+            return this.GetWinnersCount() > 0;
+        }
     }
 }

--- a/LottoDataManager.csproj
+++ b/LottoDataManager.csproj
@@ -51,6 +51,9 @@
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyModel, Version=3.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Extensions.DependencyModel.3.1.6\lib\net451\Microsoft.Extensions.DependencyModel.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.ML, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.ML.1.5.5\lib\netstandard2.0\Microsoft.ML.dll</HintPath>
     </Reference>
@@ -68,8 +71,9 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -77,11 +81,11 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=5.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Encodings.Web.5.0.1\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Encodings.Web.4.7.0\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Json.5.0.0\lib\net461\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=2.0.0.11, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Json.2.0.0.11\lib\net40\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>

--- a/LottoDataManager.csproj
+++ b/LottoDataManager.csproj
@@ -77,8 +77,8 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Encodings.Web.5.0.0\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=5.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Encodings.Web.5.0.1\lib\net461\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.Json, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Text.Json.5.0.0\lib\net461\System.Text.Json.dll</HintPath>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.6")]
-[assembly: AssemblyFileVersion("1.0.0.6")]
+[assembly: AssemblyVersion("1.0.0.7")]
+[assembly: AssemblyFileVersion("1.0.0.7")]

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -109,7 +109,7 @@ namespace LottoDataManager.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("6")]
+        [global::System.Configuration.DefaultSettingValueAttribute("7")]
         public string version_release {
             get {
                 return ((string)(this["version_release"]));

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -24,7 +24,7 @@
       <Value Profile="(Default)">0</Value>
     </Setting>
     <Setting Name="version_release" Type="System.String" Scope="User">
-      <Value Profile="(Default)">6</Value>
+      <Value Profile="(Default)">7</Value>
     </Setting>
     <Setting Name="repository_name" Type="System.String" Scope="User">
       <Value Profile="(Default)">LottoDataManager</Value>

--- a/Resources/messages_en.properties
+++ b/Resources/messages_en.properties
@@ -55,6 +55,7 @@ drpt_lot_bet_current_month_desc=Week {0}:  {1}  -  {2}   to   {3}
 drpt_lot_draw_group_lbl=Latest available draw results!
 drpt_lot_draw_value={0} ({1} day(s) ago).
 drpt_lot_draw_jackpot_lbl=Latest jackpot on each game!
+drpt_lot_draw_jackpot_winners_lbl={0}, There's {1} lucky winner(s) today!
 drpt_lot_trigger_logs_module_name=Dash Board Report Logs
 drpt_lot_trigger_logs_1=Getting your lottery bets waiting for official draw results.
 drpt_lot_trigger_logs_2=Getting the previous draw dates.
@@ -516,12 +517,13 @@ mdd_form_others_mgs7=Please review the details first before proceeding...
 mdd_form_others_mgs8=Ensure selection is correct!
 
 mdd_form_validation_msg1=Processing halted. No selected bets to change date
-mdd_form_validation_msg2=Selected draw date falls at '{0}' and the valid draw dates is every '{1}'
+mdd_form_validation_msg2=Selected draw date(s) falls at '{0}' and the valid draw days were every '{1}'
 mdd_form_validation_msg3=x - Bet {0} - {1} already exist. This will not be save.
 mdd_form_validation_msg4=o - Bet {0} - {1} has been save...
 mdd_form_validation_msg5=Selected date is too early.
-mdd_form_validation_msg6=Please select a new date that is different to your selection(s).
+mdd_form_validation_msg6=Please select a new date that is different to your currently selected target date.
 mdd_form_validation_msg7=Saving aborted....
+mdd_form_validation_msg8=Move the selected bets dated today even it is now past ticket cutoff time?
 
 #~~~~~~~~~~~ MODIFY BETS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 modfy_bets_msg_1=Modify Bet

--- a/Setup/Lotto_Data_Manager_Inno_Setup_Packaging.iss
+++ b/Setup/Lotto_Data_Manager_Inno_Setup_Packaging.iss
@@ -3,15 +3,18 @@
 
 #define MyAppName "Lotto Data Manager"
 #define MyAppVersion "1.0.0.6"
-#define MyAppPublisher "AngelsSoftwareOrg"
+#define MyAppPublisher "Angels Software Org"
 #define MyAppURL "https://github.com/AngelsSoftwareOrg"
 #define MyAppExeName "LottoDataManager.exe"
 #define InstallerName "lotto_data_manager"
+#define MyIconName "Clover_Icon.ico"
+#define MyIconPath "D:\Development\WorkSpace00002\LottoDataManager\"
+#define MyDesktopIcon MyIconPath + MyIconName
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
-AppId={{5EEAB061-7D35-4292-981C-C2A3DEC189A1}
+AppId={{B412770F-1131-403F-AF1B-25F552D42740}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 ;AppVerName={#MyAppName} {#MyAppVersion}
@@ -22,9 +25,11 @@ AppUpdatesURL={#MyAppURL}
 DefaultDirName={autopf}\{#MyAppName}
 DisableProgramGroupPage=yes
 ; Remove the following line to run in administrative install mode (install for all users.)
-PrivilegesRequired=lowest
+;PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=dialog
 OutputBaseFilename={#InstallerName}_{#MyAppVersion}_setup
+SetupIconFile={#MyDesktopIcon}
+UninstallDisplayIcon={app}\{#MyIconName}
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
@@ -38,6 +43,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 [Files]
 Source: "D:\Development\WorkSpace00002\LottoDataManager\bin\Release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
 Source: "D:\Development\WorkSpace00002\LottoDataManager\bin\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#MyDesktopIcon}"; DestDir: "{app}"; Flags: ignoreversion
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]

--- a/packages.config
+++ b/packages.config
@@ -24,7 +24,7 @@
   <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net472" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net472" />
   <package id="System.Text.Encoding.CodePages" version="5.0.0" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="5.0.0" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="5.0.1" targetFramework="net472" />
   <package id="System.Text.Json" version="5.0.0" targetFramework="net472" />
   <package id="System.Threading.Channels" version="4.7.1" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />

--- a/packages.config
+++ b/packages.config
@@ -5,7 +5,7 @@
   <package id="HtmlAgilityPack" version="1.11.31" targetFramework="net472" />
   <package id="LightGBM" version="2.2.3" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.DependencyModel" version="5.0.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyModel" version="3.1.6" targetFramework="net472" />
   <package id="Microsoft.ML" version="1.5.5" targetFramework="net472" />
   <package id="Microsoft.ML.CpuMath" version="1.5.5" targetFramework="net472" />
   <package id="Microsoft.ML.DataView" version="1.5.5" targetFramework="net472" />
@@ -17,15 +17,15 @@
   <package id="System.CodeDom" version="4.4.0" targetFramework="net472" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net472" />
   <package id="System.Collections.NonGeneric" version="4.3.0" targetFramework="net472" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.3" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
   <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net472" />
   <package id="System.Runtime.Caching" version="5.0.0" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net472" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net472" />
   <package id="System.Text.Encoding.CodePages" version="5.0.0" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="5.0.1" targetFramework="net472" />
-  <package id="System.Text.Json" version="5.0.0" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="4.7.0" targetFramework="net472" />
+  <package id="System.Text.Json" version="2.0.0.11" targetFramework="net472" />
   <package id="System.Threading.Channels" version="4.7.1" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />


### PR DESCRIPTION
- Clear out Add Bet content Form when exiting from Pick Generator
- Implement copying of selected bet list thru ctrl+c shortcut
- Implement selection of all bets on the list view thru ctrl+a shortcut
- Latest Jackpot, if latest is jackpot, then show the minimum jackpot
- When deleting a bet, ensure that the cancel button is focus first
- Refresh the main dashboard if a bet was deleted.
- Fixed saving the last opened lottery
- When moving the bet dates, it will now able to save to the current date.
- Improve Packaging Script
- Add app and uninstall icon
- Improve Publishers name
- When changing database from with and without contents, ensure that the draw result listview has been refresh.
- Fix null exception if when querying for latest bets and jackpot for each lottery when database has no records.
- Improve listing of processing logs
- Resolving Dot Net config issue
- Fix Critical Severity - System.Text.Encodings.Web vulnerability found in packages.config 28 minutes ago
