### PR TITLE
 v1.0.0.9 - Cycle Release - LottoDataManagerSetup_v1.0.0.9

### DIFF
--- a/App.config
+++ b/App.config
@@ -32,7 +32,7 @@
                 <value>0</value>
             </setting>
             <setting name="version_release" serializeAs="String">
-                <value>8</value>
+                <value>9</value>
             </setting>
             <setting name="repository_name" serializeAs="String">
                 <value>LottoDataManager</value>

--- a/Forms/MainFrm.Designer.cs
+++ b/Forms/MainFrm.Designer.cs
@@ -616,6 +616,7 @@ namespace LottoDataManager
             this.olvColBetNum6,
             this.olvColBetResult});
             this.objectLstVwLatestBet.ContextMenuStrip = this.ctxMenuBet;
+            this.objectLstVwLatestBet.CopySelectionOnControlC = false;
             this.objectLstVwLatestBet.Cursor = System.Windows.Forms.Cursors.Default;
             this.objectLstVwLatestBet.Dock = System.Windows.Forms.DockStyle.Fill;
             this.objectLstVwLatestBet.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));

--- a/Forms/Ticket/PickGeneratorFrm.Designer.cs
+++ b/Forms/Ticket/PickGeneratorFrm.Designer.cs
@@ -34,13 +34,14 @@ namespace LottoDataManager.Forms
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PickGeneratorFrm));
             this.panel1 = new System.Windows.Forms.Panel();
-            this.grpbxParam = new System.Windows.Forms.GroupBox();
-            this.panel3 = new System.Windows.Forms.Panel();
-            this.tblPnlLayParams = new System.Windows.Forms.TableLayoutPanel();
             this.grpbxGenType = new System.Windows.Forms.GroupBox();
             this.lvGenType = new BrightIdeasSoftware.ObjectListView();
             this.olvColDesc = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.grpbxParam = new System.Windows.Forms.GroupBox();
+            this.panel3 = new System.Windows.Forms.Panel();
+            this.tblPnlLayParams = new System.Windows.Forms.TableLayoutPanel();
             this.grpbxActions = new System.Windows.Forms.GroupBox();
+            this.btnStop = new System.Windows.Forms.Button();
             this.btnClearSel = new System.Windows.Forms.Button();
             this.btnGenerate = new System.Windows.Forms.Button();
             this.panel2 = new System.Windows.Forms.Panel();
@@ -62,17 +63,20 @@ namespace LottoDataManager.Forms
             this.linkUncheckAll = new System.Windows.Forms.LinkLabel();
             this.btnAddSelected = new System.Windows.Forms.Button();
             this.btnExit = new System.Windows.Forms.Button();
+            this.statusStrip1 = new System.Windows.Forms.StatusStrip();
+            this.statusLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.panel1.SuspendLayout();
-            this.grpbxParam.SuspendLayout();
-            this.panel3.SuspendLayout();
             this.grpbxGenType.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.lvGenType)).BeginInit();
+            this.grpbxParam.SuspendLayout();
+            this.panel3.SuspendLayout();
             this.grpbxActions.SuspendLayout();
             this.panel2.SuspendLayout();
             this.grpbxOutput.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.objLvGenSeq)).BeginInit();
             this.ctxMenuBet.SuspendLayout();
             this.grpbxFinalActions.SuspendLayout();
+            this.statusStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
             // panel1
@@ -84,8 +88,52 @@ namespace LottoDataManager.Forms
             this.panel1.Dock = System.Windows.Forms.DockStyle.Left;
             this.panel1.Location = new System.Drawing.Point(0, 0);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(580, 573);
+            this.panel1.Size = new System.Drawing.Size(580, 547);
             this.panel1.TabIndex = 0;
+            // 
+            // grpbxGenType
+            // 
+            this.grpbxGenType.Controls.Add(this.lvGenType);
+            this.grpbxGenType.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpbxGenType.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.grpbxGenType.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.grpbxGenType.ForeColor = System.Drawing.Color.Navy;
+            this.grpbxGenType.Location = new System.Drawing.Point(0, 0);
+            this.grpbxGenType.Name = "grpbxGenType";
+            this.grpbxGenType.Size = new System.Drawing.Size(576, 238);
+            this.grpbxGenType.TabIndex = 0;
+            this.grpbxGenType.TabStop = false;
+            this.grpbxGenType.Text = "Step 1. Choose Generator Type";
+            // 
+            // lvGenType
+            // 
+            this.lvGenType.AllColumns.Add(this.olvColDesc);
+            this.lvGenType.CellEditUseWholeCell = false;
+            this.lvGenType.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.olvColDesc});
+            this.lvGenType.Cursor = System.Windows.Forms.Cursors.Default;
+            this.lvGenType.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lvGenType.FullRowSelect = true;
+            this.lvGenType.GridLines = true;
+            this.lvGenType.HasCollapsibleGroups = false;
+            this.lvGenType.HideSelection = false;
+            this.lvGenType.Location = new System.Drawing.Point(3, 20);
+            this.lvGenType.MultiSelect = false;
+            this.lvGenType.Name = "lvGenType";
+            this.lvGenType.ShowGroups = false;
+            this.lvGenType.Size = new System.Drawing.Size(570, 215);
+            this.lvGenType.Sorting = System.Windows.Forms.SortOrder.Ascending;
+            this.lvGenType.TabIndex = 0;
+            this.lvGenType.UseCompatibleStateImageBehavior = false;
+            this.lvGenType.View = System.Windows.Forms.View.Details;
+            this.lvGenType.SelectionChanged += new System.EventHandler(this.lvGenType_SelectionChanged);
+            // 
+            // olvColDesc
+            // 
+            this.olvColDesc.AspectName = "GetDescription";
+            this.olvColDesc.Groupable = false;
+            this.olvColDesc.Text = "Description";
+            this.olvColDesc.Width = 600;
             // 
             // grpbxParam
             // 
@@ -93,7 +141,7 @@ namespace LottoDataManager.Forms
             this.grpbxParam.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.grpbxParam.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.grpbxParam.ForeColor = System.Drawing.Color.Navy;
-            this.grpbxParam.Location = new System.Drawing.Point(0, 264);
+            this.grpbxParam.Location = new System.Drawing.Point(0, 238);
             this.grpbxParam.Name = "grpbxParam";
             this.grpbxParam.Size = new System.Drawing.Size(576, 205);
             this.grpbxParam.TabIndex = 1;
@@ -127,63 +175,36 @@ namespace LottoDataManager.Forms
             this.tblPnlLayParams.Size = new System.Drawing.Size(570, 182);
             this.tblPnlLayParams.TabIndex = 0;
             // 
-            // grpbxGenType
-            // 
-            this.grpbxGenType.Controls.Add(this.lvGenType);
-            this.grpbxGenType.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.grpbxGenType.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.grpbxGenType.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.grpbxGenType.ForeColor = System.Drawing.Color.Navy;
-            this.grpbxGenType.Location = new System.Drawing.Point(0, 0);
-            this.grpbxGenType.Name = "grpbxGenType";
-            this.grpbxGenType.Size = new System.Drawing.Size(576, 264);
-            this.grpbxGenType.TabIndex = 0;
-            this.grpbxGenType.TabStop = false;
-            this.grpbxGenType.Text = "Step 1. Choose Generator Type";
-            // 
-            // lvGenType
-            // 
-            this.lvGenType.AllColumns.Add(this.olvColDesc);
-            this.lvGenType.CellEditUseWholeCell = false;
-            this.lvGenType.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.olvColDesc});
-            this.lvGenType.Cursor = System.Windows.Forms.Cursors.Default;
-            this.lvGenType.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lvGenType.FullRowSelect = true;
-            this.lvGenType.GridLines = true;
-            this.lvGenType.HasCollapsibleGroups = false;
-            this.lvGenType.HideSelection = false;
-            this.lvGenType.Location = new System.Drawing.Point(3, 20);
-            this.lvGenType.MultiSelect = false;
-            this.lvGenType.Name = "lvGenType";
-            this.lvGenType.ShowGroups = false;
-            this.lvGenType.Size = new System.Drawing.Size(570, 241);
-            this.lvGenType.Sorting = System.Windows.Forms.SortOrder.Ascending;
-            this.lvGenType.TabIndex = 0;
-            this.lvGenType.UseCompatibleStateImageBehavior = false;
-            this.lvGenType.View = System.Windows.Forms.View.Details;
-            this.lvGenType.SelectionChanged += new System.EventHandler(this.lvGenType_SelectionChanged);
-            // 
-            // olvColDesc
-            // 
-            this.olvColDesc.AspectName = "GetDescription";
-            this.olvColDesc.Groupable = false;
-            this.olvColDesc.Text = "Description";
-            this.olvColDesc.Width = 600;
-            // 
             // grpbxActions
             // 
+            this.grpbxActions.Controls.Add(this.btnStop);
             this.grpbxActions.Controls.Add(this.btnClearSel);
             this.grpbxActions.Controls.Add(this.btnGenerate);
             this.grpbxActions.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.grpbxActions.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.grpbxActions.ForeColor = System.Drawing.Color.Navy;
-            this.grpbxActions.Location = new System.Drawing.Point(0, 469);
+            this.grpbxActions.Location = new System.Drawing.Point(0, 443);
             this.grpbxActions.Name = "grpbxActions";
             this.grpbxActions.Size = new System.Drawing.Size(576, 100);
             this.grpbxActions.TabIndex = 2;
             this.grpbxActions.TabStop = false;
             this.grpbxActions.Text = "Step 3: Actions";
+            // 
+            // btnStop
+            // 
+            this.btnStop.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnStop.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnStop.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.btnStop.Image = global::LottoDataManager.Properties.Resources.stop_20;
+            this.btnStop.Location = new System.Drawing.Point(474, 23);
+            this.btnStop.Name = "btnStop";
+            this.btnStop.Size = new System.Drawing.Size(96, 67);
+            this.btnStop.TabIndex = 2;
+            this.btnStop.Text = "Stop";
+            this.btnStop.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.btnStop.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
+            this.btnStop.UseVisualStyleBackColor = true;
+            this.btnStop.Click += new System.EventHandler(this.btnStop_Click);
             // 
             // btnClearSel
             // 
@@ -191,7 +212,7 @@ namespace LottoDataManager.Forms
             this.btnClearSel.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnClearSel.ForeColor = System.Drawing.SystemColors.ControlText;
             this.btnClearSel.Image = global::LottoDataManager.Properties.Resources.erase_32px;
-            this.btnClearSel.Location = new System.Drawing.Point(231, 23);
+            this.btnClearSel.Location = new System.Drawing.Point(4, 23);
             this.btnClearSel.Name = "btnClearSel";
             this.btnClearSel.Size = new System.Drawing.Size(181, 67);
             this.btnClearSel.TabIndex = 1;
@@ -207,9 +228,9 @@ namespace LottoDataManager.Forms
             this.btnGenerate.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnGenerate.ForeColor = System.Drawing.SystemColors.ControlText;
             this.btnGenerate.Image = global::LottoDataManager.Properties.Resources.Star5_32x;
-            this.btnGenerate.Location = new System.Drawing.Point(419, 23);
+            this.btnGenerate.Location = new System.Drawing.Point(192, 23);
             this.btnGenerate.Name = "btnGenerate";
-            this.btnGenerate.Size = new System.Drawing.Size(143, 67);
+            this.btnGenerate.Size = new System.Drawing.Size(156, 67);
             this.btnGenerate.TabIndex = 0;
             this.btnGenerate.Text = "Generate";
             this.btnGenerate.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -225,7 +246,7 @@ namespace LottoDataManager.Forms
             this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel2.Location = new System.Drawing.Point(580, 0);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(597, 573);
+            this.panel2.Size = new System.Drawing.Size(597, 547);
             this.panel2.TabIndex = 1;
             // 
             // grpbxOutput
@@ -236,7 +257,7 @@ namespace LottoDataManager.Forms
             this.grpbxOutput.ForeColor = System.Drawing.Color.Navy;
             this.grpbxOutput.Location = new System.Drawing.Point(0, 0);
             this.grpbxOutput.Name = "grpbxOutput";
-            this.grpbxOutput.Size = new System.Drawing.Size(593, 439);
+            this.grpbxOutput.Size = new System.Drawing.Size(593, 413);
             this.grpbxOutput.TabIndex = 0;
             this.grpbxOutput.TabStop = false;
             this.grpbxOutput.Text = "Step 4: Output";
@@ -273,7 +294,7 @@ namespace LottoDataManager.Forms
             this.objLvGenSeq.SelectedColumnTint = System.Drawing.Color.FromArgb(((int)(((byte)(15)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
             this.objLvGenSeq.SelectedForeColor = System.Drawing.Color.White;
             this.objLvGenSeq.ShowGroups = false;
-            this.objLvGenSeq.Size = new System.Drawing.Size(587, 416);
+            this.objLvGenSeq.Size = new System.Drawing.Size(587, 390);
             this.objLvGenSeq.TabIndex = 1;
             this.objLvGenSeq.UseCompatibleStateImageBehavior = false;
             this.objLvGenSeq.View = System.Windows.Forms.View.Details;
@@ -350,7 +371,7 @@ namespace LottoDataManager.Forms
             this.grpbxFinalActions.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.grpbxFinalActions.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.grpbxFinalActions.ForeColor = System.Drawing.Color.Navy;
-            this.grpbxFinalActions.Location = new System.Drawing.Point(0, 439);
+            this.grpbxFinalActions.Location = new System.Drawing.Point(0, 413);
             this.grpbxFinalActions.Name = "grpbxFinalActions";
             this.grpbxFinalActions.Size = new System.Drawing.Size(593, 130);
             this.grpbxFinalActions.TabIndex = 1;
@@ -419,6 +440,23 @@ namespace LottoDataManager.Forms
             this.btnExit.UseVisualStyleBackColor = true;
             this.btnExit.Click += new System.EventHandler(this.btnExit_Click);
             // 
+            // statusStrip1
+            // 
+            this.statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.statusLabel});
+            this.statusStrip1.Location = new System.Drawing.Point(0, 547);
+            this.statusStrip1.Name = "statusStrip1";
+            this.statusStrip1.Size = new System.Drawing.Size(1177, 26);
+            this.statusStrip1.TabIndex = 2;
+            this.statusStrip1.Text = "statusStrip1";
+            // 
+            // statusLabel
+            // 
+            this.statusLabel.Name = "statusLabel";
+            this.statusLabel.Size = new System.Drawing.Size(115, 20);
+            this.statusLabel.Text = "Sample Content";
+            // 
             // PickGeneratorFrm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
@@ -427,6 +465,7 @@ namespace LottoDataManager.Forms
             this.ClientSize = new System.Drawing.Size(1177, 573);
             this.Controls.Add(this.panel2);
             this.Controls.Add(this.panel1);
+            this.Controls.Add(this.statusStrip1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MinimizeBox = false;
             this.Name = "PickGeneratorFrm";
@@ -435,11 +474,11 @@ namespace LottoDataManager.Forms
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.PickGeneratorFrm_FormClosing);
             this.Load += new System.EventHandler(this.PickGeneratorFrm_Load);
             this.panel1.ResumeLayout(false);
+            this.grpbxGenType.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.lvGenType)).EndInit();
             this.grpbxParam.ResumeLayout(false);
             this.panel3.ResumeLayout(false);
             this.panel3.PerformLayout();
-            this.grpbxGenType.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.lvGenType)).EndInit();
             this.grpbxActions.ResumeLayout(false);
             this.panel2.ResumeLayout(false);
             this.grpbxOutput.ResumeLayout(false);
@@ -447,7 +486,10 @@ namespace LottoDataManager.Forms
             this.ctxMenuBet.ResumeLayout(false);
             this.grpbxFinalActions.ResumeLayout(false);
             this.grpbxFinalActions.PerformLayout();
+            this.statusStrip1.ResumeLayout(false);
+            this.statusStrip1.PerformLayout();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -482,5 +524,8 @@ namespace LottoDataManager.Forms
         private OLVColumn olvNum4;
         private OLVColumn olvNum5;
         private OLVColumn olvNum6;
+        private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.ToolStripStatusLabel statusLabel;
+        private System.Windows.Forms.Button btnStop;
     }
 }

--- a/Forms/Ticket/PickGeneratorFrm.cs
+++ b/Forms/Ticket/PickGeneratorFrm.cs
@@ -236,6 +236,8 @@ namespace LottoDataManager.Forms
             objLvGenSeq.Tag = null;
             ClearSequenceGenParametersValue();
             statusLabel.Text = String.Empty;
+            this.objLvGenSeq.ModelFilter = null;
+            this.objLvGenSeq.DefaultRenderer = null;
         }
         private void ClearSequenceGenParametersValue()
         {
@@ -292,6 +294,8 @@ namespace LottoDataManager.Forms
                 btnClearSel.Enabled = false;
                 btnGenerate.Enabled = false;
                 btnStop.Visible = true;
+                this.objLvGenSeq.ModelFilter = null;
+                this.objLvGenSeq.DefaultRenderer = null;
             }
             else
             {
@@ -436,7 +440,6 @@ namespace LottoDataManager.Forms
             AutoCheckSelectedBetsFromHitComparisonForm(hitComparisonFrm.GetCheckedLotteryBets);
             hitComparisonFrm.Dispose();
         }
-
         private void AutoCheckSelectedBetsFromHitComparisonForm(List<LotteryBet> selectedLotteryBets)
         {
             LotteryBet seqGenVisibleItem = null;
@@ -454,7 +457,5 @@ namespace LottoDataManager.Forms
             //ensure last item check is visible/auto scroll
             if (seqGenVisibleItem != null) objLvGenSeq.EnsureModelVisible(seqGenVisibleItem);
         }
-
-
     }
 }

--- a/Forms/Ticket/PickGeneratorFrm.cs
+++ b/Forms/Ticket/PickGeneratorFrm.cs
@@ -12,6 +12,7 @@ using LottoDataManager.Forms.Others;
 using LottoDataManager.Includes.Classes;
 using LottoDataManager.Includes.Classes.Comparers;
 using LottoDataManager.Includes.Classes.Generator;
+using LottoDataManager.Includes.Classes.Generator.PickGenerationProgress;
 using LottoDataManager.Includes.Classes.Generator.Types;
 using LottoDataManager.Includes.Model;
 using LottoDataManager.Includes.Model.Details;
@@ -27,7 +28,8 @@ namespace LottoDataManager.Forms
         private LotteryDataServices lotteryDataServices;
         private LotteryTicketPanel lotteryTicketPanel;
         private SequenceGeneratorParamFieldsFormFactory seqFactory = SequenceGeneratorParamFieldsFormFactory.GetInstance();
-        
+        private String statusPickGenerationLabelCache;
+        private bool isPickGeneratorRunningStatus;
         public PickGeneratorFrm(LotteryDataServices lotteryDataServices)
         {
             InitializeComponent();
@@ -37,6 +39,7 @@ namespace LottoDataManager.Forms
 
         private void PickGeneratorFrm_Load(object sender, EventArgs e)
         {
+            statusLabel.Text = String.Empty;
             this.Text = String.Format(ResourcesUtils.GetMessage("pick_grp_gen_form_title"),
                 this.lotteryDataServices.LotteryDetails.Description);
             btnViewCompareHits.Text = ResourcesUtils.GetMessage("pick_btn_compare_hits");
@@ -50,6 +53,10 @@ namespace LottoDataManager.Forms
             btnAddSelected.Text = ResourcesUtils.GetMessage("pick_btn_place_bet");
             btnExit.Text = ResourcesUtils.GetMessage("common_btn_exit");
             linkUncheckAll.Text = ResourcesUtils.GetMessage("common_link_uncheck_all");
+            btnStop.Text = ResourcesUtils.GetMessage("common_btn_stop");
+            statusPickGenerationLabelCache = ResourcesUtils.GetMessage("pick_status_lbl_pick_generation");
+            btnStop.Visible = false;
+            isPickGeneratorRunningStatus = false;
             SetupObjectListView();
             EnlistGenerators();
         }
@@ -228,6 +235,7 @@ namespace LottoDataManager.Forms
             objLvGenSeq.SetObjects(null);
             objLvGenSeq.Tag = null;
             ClearSequenceGenParametersValue();
+            statusLabel.Text = String.Empty;
         }
         private void ClearSequenceGenParametersValue()
         {
@@ -243,13 +251,59 @@ namespace LottoDataManager.Forms
             if (lvGenType.SelectedObjects.Count > 0)
             {
                 SequenceGenerator seqGen = (SequenceGenerator)lvGenType.SelectedObject;
+                AbstractSequenceGenerator seqGenAbstract = (AbstractSequenceGenerator) seqGen;
+                seqGenAbstract.PickGenerationProgress += SeqGenAbstract_PickGenerationProgress;
+                isPickGeneratorRunningStatus = true;
                 String errMsg = "";
                 if(!seqGen.AreParametersValueValid(out errMsg))
                 {
                     MessageBox.Show(errMsg);
                     return;
                 }
+                ButtonAvailabilityWhilePicking(true);
                 DisplayGeneratedSequence(seqGen.GenerateSequence());
+            }
+            ButtonAvailabilityWhilePicking(false);
+        }
+        private void SeqGenAbstract_PickGenerationProgress(object sender, PickGenerationProgressEvent e)
+        {
+            if(isPickGeneratorRunningStatus == false)
+            {
+                SequenceGenerator seqGen = (SequenceGenerator)lvGenType.SelectedObject;
+                AbstractSequenceGenerator seqGenAbstract = (AbstractSequenceGenerator)seqGen;
+                if (seqGenAbstract == null) return;
+                seqGenAbstract.StopPickGeneration();
+            }
+            statusLabel.Text = String.Format(statusPickGenerationLabelCache, e.GeneratedPickCount, e.GenerationAttemptCount);
+            if (e.GenerationAttemptCount % 200 == 0) Application.DoEvents();
+        }
+        private void btnStop_Click(object sender, EventArgs e)
+        {
+            isPickGeneratorRunningStatus = false;
+        }
+        private void ButtonAvailabilityWhilePicking(bool isPicking)
+        {
+            if (isPicking)
+            {
+                addBetToolStripMenuItem.Enabled = false;
+                lvGenType.Enabled = false;
+                btnAddSelected.Enabled = false;
+                btnViewCompareHits.Enabled = false;
+                btnClearSel.Enabled = false;
+                btnGenerate.Enabled = false;
+                btnStop.Visible = true;
+            }
+            else
+            {
+                addBetToolStripMenuItem.Enabled = true;
+                lvGenType.Enabled = true;
+                btnAddSelected.Enabled = true;
+                btnViewCompareHits.Enabled = true;
+                btnClearSel.Enabled = true;
+                btnGenerate.Enabled = true;
+                btnStop.Visible = false;
+                isPickGeneratorRunningStatus = false;
+                statusLabel.Text = String.Empty;
             }
         }
         private void lvGenType_SelectionChanged(object sender, EventArgs e)
@@ -293,6 +347,7 @@ namespace LottoDataManager.Forms
         #endregion
         private void btnExit_Click(object sender, EventArgs e)
         {
+            this.btnStop_Click(sender, e);
             this.Close();
         }
         private void linkUncheckAll_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
@@ -399,5 +454,7 @@ namespace LottoDataManager.Forms
             //ensure last item check is visible/auto scroll
             if (seqGenVisibleItem != null) objLvGenSeq.EnsureModelVisible(seqGenVisibleItem);
         }
+
+
     }
 }

--- a/Forms/Ticket/PickGeneratorFrm.resx
+++ b/Forms/Ticket/PickGeneratorFrm.resx
@@ -120,6 +120,9 @@
   <metadata name="ctxMenuBet.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>155, 17</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/Includes/Classes/Generator/AbstractSequenceGenerator.cs
+++ b/Includes/Classes/Generator/AbstractSequenceGenerator.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using LottoDataManager.Includes.Classes.Generator.PickGenerationProgress;
 using LottoDataManager.Includes.Model.Details;
 using LottoDataManager.Includes.Utilities;
 
 namespace LottoDataManager.Includes.Classes.Generator
 {
-    public abstract class AbstractSequenceGenerator
+    public abstract class AbstractSequenceGenerator: AbstractPickGenerationProgress
     {
         private String description;
         private List<SequenceGeneratorParams> sequenceParams;
@@ -17,9 +18,9 @@ namespace LottoDataManager.Includes.Classes.Generator
         protected LotteryTicketPanel lotteryTicketPanel;
         protected static int IN_BETWEEN_SUM_MIN = 104;
         protected static int IN_BETWEEN_SUM_MAX = 176;
-
+        
         private GeneratorType seqGeneratorType;
-        protected AbstractSequenceGenerator(LotteryDataServices lotteryDataServices)
+        protected AbstractSequenceGenerator(LotteryDataServices lotteryDataServices): base()
         {
             this.lotteryDataServices = lotteryDataServices;
             this.lotteryTicketPanel = this.lotteryDataServices.GetLotteryTicketPanel();

--- a/Includes/Classes/Generator/PickGenerationProgress/AbstractPickGenerationProgress.cs
+++ b/Includes/Classes/Generator/PickGenerationProgress/AbstractPickGenerationProgress.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LottoDataManager.Includes.Classes.Generator.PickGenerationProgress
+{
+    public abstract class AbstractPickGenerationProgress
+    {
+        public event EventHandler<PickGenerationProgressEvent> PickGenerationProgress;
+        private PickGenerationProgressEvent pickGenerationProgressEvent;
+        private Boolean isPickGenerationRunning;
+        protected AbstractPickGenerationProgress()
+        {
+            pickGenerationProgressEvent = new PickGenerationProgressEvent();
+            IsPickGenerationRunning = false;
+        }
+        protected PickGenerationProgressEvent PickGenerationProgressEvent { get => pickGenerationProgressEvent; }
+        public bool IsPickGenerationRunning { get => isPickGenerationRunning; set => isPickGenerationRunning = value; }
+        protected void RaisePickGenerationProgress()
+        {
+            if (PickGenerationProgress == null) return;
+            PickGenerationProgress.Invoke(this, PickGenerationProgressEvent);
+        }
+        protected bool IsContinuePickGenerationProgress()
+        {
+            RaisePickGenerationProgress();
+            if (!IsPickGenerationRunning) return false;
+            if (PickGenerationProgressEvent.IsGenerationAttemptCountReachMaxValue()) return false;
+            return true;
+        }
+        public void ResetPickGenerationStats()
+        {
+            PickGenerationProgressEvent.ResetCounters();
+        }
+        protected void StartPickGeneration()
+        {
+            IsPickGenerationRunning = true;
+            ResetPickGenerationStats();
+        }
+        public void StopPickGeneration()
+        {
+            IsPickGenerationRunning = false;
+        }
+    }
+}

--- a/Includes/Classes/Generator/PickGenerationProgress/PickGenerationProgressEvent.cs
+++ b/Includes/Classes/Generator/PickGenerationProgress/PickGenerationProgressEvent.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LottoDataManager.Includes.Classes.Generator.PickGenerationProgress
+{
+    public class PickGenerationProgressEvent : EventArgs
+    {
+        private int generatedPickCount;
+        private long generationAttemptCount;
+        private long maxAttempt;
+
+        public PickGenerationProgressEvent()
+        {
+            maxAttempt = long.MaxValue - 100;
+            ResetCounters();
+        }
+        public int GeneratedPickCount { get => generatedPickCount; set => generatedPickCount = value; }
+        public long GenerationAttemptCount { get => generationAttemptCount; set => generationAttemptCount = value; }
+
+        public void ResetCounters()
+        {
+            GeneratedPickCount = 0;
+            GenerationAttemptCount = 0;
+        }
+        public void IncrementGeneratedPickCount()
+        {
+            GeneratedPickCount++;
+        }
+        public void IncrementGenerationAttemptCount()
+        {
+            GenerationAttemptCount++;
+        }
+        public bool IsGenerationAttemptCountReachMaxValue()
+        {
+            return (GenerationAttemptCount > maxAttempt);
+        }
+    }
+}

--- a/Includes/Classes/Generator/Types/LottoCountMatchPredictionFastTreeRegression.cs
+++ b/Includes/Classes/Generator/Types/LottoCountMatchPredictionFastTreeRegression.cs
@@ -38,9 +38,10 @@ namespace LottoDataManager.Includes.Classes.Generator.Types
 
         public List<int[]> GenerateSequence()
         {
+            StartPickGeneration();
             int maximumPickCount = GetFieldParamValueForCount(0);
             int matchPerc = GetFieldParamValueForCount(1);
-            int maxLoopBreaker = 100000;
+            int maxLoopBreaker = int.MaxValue - 100;
             int maxLoopCtr = 0;
             List<int[]> results = new List<int[]>();
             LottoMatchCountInputModel sampleData;
@@ -56,11 +57,14 @@ namespace LottoDataManager.Includes.Classes.Generator.Types
                 sampleData = lotteryBet.GetLottoMatchCountInputModel();
                 LottoMatchCountOutputModel output = LottoMatchCountPredictor.Predict(sampleData);
                 int score = (int)(output.Score * 100);
+                PickGenerationProgressEvent.IncrementGenerationAttemptCount();
                 if (score >= matchPerc)
                 {
                     Array.Sort(randomSeq);
                     results.Add(randomSeq);
+                    PickGenerationProgressEvent.IncrementGeneratedPickCount();
                 }
+                if (!IsContinuePickGenerationProgress()) break;
                 if (maxLoopCtr++ > maxLoopBreaker) break;
             }
             return results;

--- a/LottoDataManager.csproj
+++ b/LottoDataManager.csproj
@@ -183,9 +183,11 @@
     <Compile Include="Includes\Classes\Comparers\ListviewIntSorter.cs" />
     <Compile Include="Includes\Classes\Comparers\ListviewTextSorter.cs" />
     <Compile Include="Includes\Classes\Extensions\ControlExtensions.cs" />
+    <Compile Include="Includes\Classes\Generator\PickGenerationProgress\AbstractPickGenerationProgress.cs" />
     <Compile Include="Includes\Classes\Generator\AbstractSequenceGenerator.cs" />
     <Compile Include="Includes\Classes\Generator\GeneratorParamType.cs" />
     <Compile Include="Includes\Classes\Generator\GeneratorType.cs" />
+    <Compile Include="Includes\Classes\Generator\PickGenerationProgress\PickGenerationProgressEvent.cs" />
     <Compile Include="Includes\Classes\Generator\Types\DrawResultWinCountFastTreeTweedieRandomGenerator.cs" />
     <Compile Include="Includes\Classes\Generator\Types\LottoCountMatchPredictionFastTreeRegression.cs" />
     <Compile Include="Includes\Classes\Generator\Types\NumberNotYetPickUpGenerator.cs" />

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.8")]
-[assembly: AssemblyFileVersion("1.0.0.8")]
+[assembly: AssemblyVersion("1.0.0.9")]
+[assembly: AssemblyFileVersion("1.0.0.9")]

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -109,7 +109,7 @@ namespace LottoDataManager.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("8")]
+        [global::System.Configuration.DefaultSettingValueAttribute("9")]
         public string version_release {
             get {
                 return ((string)(this["version_release"]));

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -24,7 +24,7 @@
       <Value Profile="(Default)">0</Value>
     </Setting>
     <Setting Name="version_release" Type="System.String" Scope="User">
-      <Value Profile="(Default)">8</Value>
+      <Value Profile="(Default)">9</Value>
     </Setting>
     <Setting Name="repository_name" Type="System.String" Scope="User">
       <Value Profile="(Default)">LottoDataManager</Value>

--- a/Resources/messages_en.properties
+++ b/Resources/messages_en.properties
@@ -91,6 +91,7 @@ common_btn_refresh=Refresh
 common_btn_save_changes=Save Changes
 common_btn_restore_back=Restore Back the List
 common_btn_save_sequences=Save Sequence(s)
+common_btn_stop=Stop
 common_cal_date_from=Date from: 
 common_cal_date_to=Date to: 
 common_calendar_month_lbl_1=January
@@ -183,7 +184,7 @@ pick_btn_clr_sel=Clear Selections
 pick_btn_generate=Generate
 pick_btn_place_bet=Place checked as bet
 pick_btn_compare_hits=Compare Hits
-
+pick_status_lbl_pick_generation=Generated pick {0} out of {1}...
 
 #~~~~~~~~~~~ PICK GENERATOR CLASS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 pick_class_luckypick_desc=Lucky Pick Generator


### PR DESCRIPTION
- Add progress bar on Pick Generator, for the selected pick generators type
- Remove the native ctrl+c function of object list view for Bets only.
- Clear out the highlight renderer on Pick Generator form pick list when generating or clearing the current list.
